### PR TITLE
Add whiteboard token gen support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,7 @@ go 1.20
 require (
 	github.com/AgoraIO-Community/go-tokenbuilder v1.2.0
 	github.com/joho/godotenv v1.5.1
+	github.com/netless-io/netless-token/golang v0.0.0-20220615025308-771ff36bfc1e
 )
+
+require github.com/google/uuid v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
 github.com/AgoraIO-Community/go-tokenbuilder v1.2.0 h1:Ktlv7n8PhmSap3tgNxjNHO8hj/qydUIj4UOFF8tRxos=
 github.com/AgoraIO-Community/go-tokenbuilder v1.2.0/go.mod h1:xqPdaiFG00M1hNN/CCYh8j+NTmkiJsQtqYdf4YAlncA=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/netless-io/netless-token/golang v0.0.0-20220615025308-771ff36bfc1e h1:Ax7sgcxR2imc/YLr5LlWWvnC9jQvL1pF49Iixgn6V5g=
+github.com/netless-io/netless-token/golang v0.0.0-20220615025308-771ff36bfc1e/go.mod h1:S1Qba7Owf/1hqvt59TLA2oU++JlBcJrQnvsJJ/SJhFA=

--- a/service/https_handlers.go
+++ b/service/https_handlers.go
@@ -183,7 +183,7 @@ func ChatToken(w http.ResponseWriter, r *http.Request) {
 }
 
 // Create Whiteboard SDK token
-func SDKToken(w http.ResponseWriter, r *http.Request) {
+func WhiteboardSDKToken(w http.ResponseWriter, r *http.Request) {
 	log.Println("Generating Whiteboard SDK token")
 	var tokenRequest SDKTokenReq
 	err := json.NewDecoder(r.Body).Decode(&tokenRequest)
@@ -212,7 +212,7 @@ func SDKToken(w http.ResponseWriter, r *http.Request) {
 }
 
 // Create Whiteboard Room token
-func RoomToken(w http.ResponseWriter, r *http.Request) {
+func WhiteboardRoomToken(w http.ResponseWriter, r *http.Request) {
 	log.Println("Generating Whiteboard Room token")
 	var tokenRequest RoomTokenReq
 	err := json.NewDecoder(r.Body).Decode(&tokenRequest)
@@ -242,7 +242,7 @@ func RoomToken(w http.ResponseWriter, r *http.Request) {
 }
 
 // Create Whiteboard Task token
-func TaskToken(w http.ResponseWriter, r *http.Request) {
+func WhiteboardTaskToken(w http.ResponseWriter, r *http.Request) {
 	log.Println("Generating Whiteboard task token")
 	var tokenRequest TaskTokenReq
 	err := json.NewDecoder(r.Body).Decode(&tokenRequest)

--- a/service/https_handlers.go
+++ b/service/https_handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AgoraIO-Community/go-tokenbuilder/chatTokenBuilder"
 	rtctokenbuilder2 "github.com/AgoraIO-Community/go-tokenbuilder/rtctokenbuilder"
 	rtmtokenbuilder2 "github.com/AgoraIO-Community/go-tokenbuilder/rtmtokenbuilder"
+	whiteboardtokenbuilder "github.com/netless-io/netless-token/golang"
 )
 
 type RtcTokenReq struct {
@@ -34,6 +35,29 @@ type ChatTokenReq struct {
 	AppCertificate string `json:"certificate"`
 	Uid            string `json:"uid"`
 	Expiration     int    `json:"expire,omitempty"`
+}
+
+type SDKTokenReq struct {
+	Role       string `json:"role"`
+	AccessKey  string `json:"accessKey"`
+	SecretKey  string `json:"SecretKey"`
+	Expiration int    `json:"expire,omitempty"`
+}
+
+type RoomTokenReq struct {
+	Role       string `json:"role"`
+	AccessKey  string `json:"accessKey"`
+	SecretKey  string `json:"SecretKey"`
+	Expiration int    `json:"expire,omitempty"`
+	RoomUuid   string `json:"roomuuid"`
+}
+
+type TaskTokenReq struct {
+	Role       string `json:"role"`
+	AccessKey  string `json:"accessKey"`
+	SecretKey  string `json:"SecretKey"`
+	Expiration int    `json:"expire,omitempty"`
+	TaskUuid   string `json:"taskuuid"`
 }
 
 func RtcToken(w http.ResponseWriter, r *http.Request) {
@@ -155,6 +179,95 @@ func ChatToken(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"chatToken": chatToken,
+	})
+}
+
+// Create Whiteboard SDK token
+func SDKToken(w http.ResponseWriter, r *http.Request) {
+	log.Println("Generating Whiteboard SDK token")
+	var tokenRequest SDKTokenReq
+	err := json.NewDecoder(r.Body).Decode(&tokenRequest)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	content := whiteboardtokenbuilder.SDKContent{
+		Role: tokenRequest.Role,
+	}
+
+	sdkToken := whiteboardtokenbuilder.SDKToken(
+		tokenRequest.AccessKey,
+		tokenRequest.SecretKey,
+		int64(tokenRequest.Expiration),
+		&content,
+	)
+
+	log.Println("Whiteboard SDK token generated")
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"sdkToken": sdkToken,
+	})
+}
+
+// Create Whiteboard Room token
+func RoomToken(w http.ResponseWriter, r *http.Request) {
+	log.Println("Generating Whiteboard Room token")
+	var tokenRequest RoomTokenReq
+	err := json.NewDecoder(r.Body).Decode(&tokenRequest)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	content := whiteboardtokenbuilder.RoomContent{
+		Role: tokenRequest.Role,
+		Uuid: tokenRequest.RoomUuid,
+	}
+
+	roomToken := whiteboardtokenbuilder.RoomToken(
+		tokenRequest.AccessKey,
+		tokenRequest.SecretKey,
+		int64(tokenRequest.Expiration),
+		&content,
+	)
+
+	log.Println("Whiteboard room token generated")
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"roomToken": roomToken,
+	})
+}
+
+// Create Whiteboard Task token
+func TaskToken(w http.ResponseWriter, r *http.Request) {
+	log.Println("Generating Whiteboard task token")
+	var tokenRequest TaskTokenReq
+	err := json.NewDecoder(r.Body).Decode(&tokenRequest)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	content := whiteboardtokenbuilder.TaskContent{
+		Role: tokenRequest.Role,
+		Uuid: tokenRequest.TaskUuid,
+	}
+
+	taskToken := whiteboardtokenbuilder.TaskToken(
+		tokenRequest.AccessKey,
+		tokenRequest.SecretKey,
+		int64(tokenRequest.Expiration),
+		&content,
+	)
+
+	log.Println("Whiteboard task token generated")
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"taskToken": taskToken,
 	})
 }
 

--- a/service/https_handlers.go
+++ b/service/https_handlers.go
@@ -37,14 +37,14 @@ type ChatTokenReq struct {
 	Expiration     int    `json:"expire,omitempty"`
 }
 
-type SDKTokenReq struct {
+type WhiteboardSDKTokenReq struct {
 	Role       string `json:"role"`
 	AccessKey  string `json:"accessKey"`
 	SecretKey  string `json:"SecretKey"`
 	Expiration int    `json:"expire,omitempty"`
 }
 
-type RoomTokenReq struct {
+type WhiteboardRoomTokenReq struct {
 	Role       string `json:"role"`
 	AccessKey  string `json:"accessKey"`
 	SecretKey  string `json:"SecretKey"`
@@ -52,7 +52,7 @@ type RoomTokenReq struct {
 	RoomUuid   string `json:"roomuuid"`
 }
 
-type TaskTokenReq struct {
+type WhiteboardTaskTokenReq struct {
 	Role       string `json:"role"`
 	AccessKey  string `json:"accessKey"`
 	SecretKey  string `json:"SecretKey"`
@@ -185,7 +185,7 @@ func ChatToken(w http.ResponseWriter, r *http.Request) {
 // Create Whiteboard SDK token
 func WhiteboardSDKToken(w http.ResponseWriter, r *http.Request) {
 	log.Println("Generating Whiteboard SDK token")
-	var tokenRequest SDKTokenReq
+	var tokenRequest WhiteboardSDKTokenReq
 	err := json.NewDecoder(r.Body).Decode(&tokenRequest)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -214,7 +214,7 @@ func WhiteboardSDKToken(w http.ResponseWriter, r *http.Request) {
 // Create Whiteboard Room token
 func WhiteboardRoomToken(w http.ResponseWriter, r *http.Request) {
 	log.Println("Generating Whiteboard Room token")
-	var tokenRequest RoomTokenReq
+	var tokenRequest WhiteboardRoomTokenReq
 	err := json.NewDecoder(r.Body).Decode(&tokenRequest)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -244,7 +244,7 @@ func WhiteboardRoomToken(w http.ResponseWriter, r *http.Request) {
 // Create Whiteboard Task token
 func WhiteboardTaskToken(w http.ResponseWriter, r *http.Request) {
 	log.Println("Generating Whiteboard task token")
-	var tokenRequest TaskTokenReq
+	var tokenRequest WhiteboardTaskTokenReq
 	err := json.NewDecoder(r.Body).Decode(&tokenRequest)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/service/service.go
+++ b/service/service.go
@@ -62,6 +62,9 @@ func NewService() *Service {
 	mux.HandleFunc("/rtc", RtcToken)
 	mux.HandleFunc("/rtm", RtmToken)
 	mux.HandleFunc("/chat", ChatToken)
+	mux.HandleFunc("/sdk-token", SDKToken)
+	mux.HandleFunc("/room-token", RoomToken)
+	mux.HandleFunc("/task-token", TaskToken)
 
 	s := &Service{
 		Sigint: make(chan os.Signal, 1),

--- a/service/service.go
+++ b/service/service.go
@@ -62,9 +62,9 @@ func NewService() *Service {
 	mux.HandleFunc("/rtc", RtcToken)
 	mux.HandleFunc("/rtm", RtmToken)
 	mux.HandleFunc("/chat", ChatToken)
-	mux.HandleFunc("/sdk-token", SDKToken)
-	mux.HandleFunc("/room-token", RoomToken)
-	mux.HandleFunc("/task-token", TaskToken)
+	mux.HandleFunc("/sdk-token", WhiteboardSDKToken)
+	mux.HandleFunc("/room-token", WhiteboardRoomToken)
+	mux.HandleFunc("/task-token", WhiteboardTaskToken)
 
 	s := &Service{
 		Sigint: make(chan os.Signal, 1),


### PR DESCRIPTION
This PR:
- Uses https://github.com/netless-io/netless-token/tree/master/golang to generate whiteboard tokens
- Add 3 endpoints for the 3 types of tokens in WB SDK.